### PR TITLE
OAuth 初回認証時に 301 が返ってくる

### DIFF
--- a/lib/tw/client/auth.rb
+++ b/lib/tw/client/auth.rb
@@ -32,7 +32,7 @@ module Tw
 
     def self.regist_user
       consumer = OAuth::Consumer.new(Conf['consumer_key'], Conf['consumer_secret'],
-                                     :site => 'http://twitter.com')
+                                     :site => 'http://api.twitter.com')
       request_token = consumer.get_request_token
       puts cmd = "open #{request_token.authorize_url}"
       system cmd


### PR DESCRIPTION
初回起動時に OAuth 認証で 301 が返ってきてエラーとなる問題を修正しました。

```
$ tw
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:2105:in `error!': 301 "Moved Permanently" (Net::HTTPRetriableError)
        from /Library/Ruby/Gems/1.8/gems/oauth-0.4.7/lib/oauth/consumer.rb:213:in `token_request'
        from /Library/Ruby/Gems/1.8/gems/oauth-0.4.7/lib/oauth/consumer.rb:136:in `get_request_token'
        from /Library/Ruby/Gems/1.8/gems/tw-0.3.8/lib/tw/client/auth.rb:36:in `regist_user'
        from /Library/Ruby/Gems/1.8/gems/tw-0.3.8/lib/tw/client/auth.rb:29:in `get_or_regist_user'
        from /Library/Ruby/Gems/1.8/gems/tw-0.3.8/lib/tw/client/auth.rb:12:in `auth'
        from /Library/Ruby/Gems/1.8/gems/tw-0.3.8/lib/tw/client/auth.rb:5:in `auth'
        from /Library/Ruby/Gems/1.8/gems/tw-0.3.8/lib/tw/app/main.rb:137:in `auth'
        from /Library/Ruby/Gems/1.8/gems/tw-0.3.8/lib/tw/app/main.rb:104:in `run'
        from /Library/Ruby/Gems/1.8/gems/tw-0.3.8/bin/tw:9
        from /usr/bin/tw:19:in `load'
        from /usr/bin/tw:19
```
