### PR TITLE
OAuth::Consumer#new に渡すURLをHTTPSに変更

### DIFF
--- a/lib/tw/client/auth.rb
+++ b/lib/tw/client/auth.rb
@@ -39,7 +39,7 @@ module Tw
 
     def self.regist_user
       consumer = OAuth::Consumer.new(Conf['consumer_key'], Conf['consumer_secret'],
-                                     :site => 'http://api.twitter.com')
+                                     :site => 'https://api.twitter.com')
       request_token = consumer.get_request_token
       puts "open #{request_token.authorize_url}"
       Launchy.open request_token.authorize_url


### PR DESCRIPTION
エラーが出たので（たぶんTwitter側でHTTPS以外を弾くようになったせい）
