### PR TITLE
use home timeline as default action

### DIFF
--- a/lib/tw/app/main.rb
+++ b/lib/tw/app/main.rb
@@ -114,6 +114,10 @@ module Tw::App
 
       regist_cmds
 
+      if @args.argv.empty? and @args.params.values.reject{|v| v[:value].nil?}.empty?
+        @args.params[:timeline][:value] = true
+      end
+
       cmds.each do |name, cmd|
         next unless @args[name]
         cmd.call @args[name], @args


### PR DESCRIPTION
オプションも引数も指定されていない場合に何も表示されなかったので、デフォルトの動きとしてホームタイムラインを表示するようにしてみました。
