### PR TITLE
ツイートの確認のときに`/^y/`とエンターだけacceptする

### DIFF
--- a/lib/tw/app/main.rb
+++ b/lib/tw/app/main.rb
@@ -157,7 +157,7 @@ module Tw::App
             while true
               puts '[Y/n]'
               case STDIN.gets.strip
-              when /^y/i
+              when /^y/i, ""
                 break
               when /^n/i
                 on_exit

--- a/lib/tw/app/main.rb
+++ b/lib/tw/app/main.rb
@@ -154,8 +154,15 @@ module Tw::App
             end
           end
           unless @args.has_option? :yes
-            puts '[Y/n]'
-            on_exit if STDIN.gets.strip =~ /^n/i
+            while true
+              puts '[Y/n]'
+              case STDIN.gets.strip
+              when /^y/i
+                break
+              when /^n/i
+                on_exit
+              end
+            end
           end
         end
         begin


### PR DESCRIPTION
現在はツイートの確認のときに`/^n/`以外の入力でも全てツイートできるようになっていますが、誤って他のキーなどを押したときもツイートされると困る場面があると考えたので、`/^y/`が入力されたときにツイートするように変更しました。また気軽さを維持するためにEnterキー(空文字の入力)でもツイートできた方がいいと判断し空文字もacceptするようにしています。

またテストを書こうと考えているのですが、もう少し修正が必要なので今回はこの変更でPRを送らせていただいています。方法としては、[Y/n]のツイート確認部分だけメソッドで切り出してそこだけテストするなどの方法があると考えていてそちらも実装しようと考えているのですが、何かご意見・アイディア等あればお願いいたします。
